### PR TITLE
Make the Glossa biblatex files backward compatible

### DIFF
--- a/biblatex-gl.bbx
+++ b/biblatex-gl.bbx
@@ -3,7 +3,17 @@
 % NB: The Unified Style Sheet wants abbreviated "ed(s)", "edn". But using the abbreviate option also abbreviates the names of months. But then dateabbrev=false restores the long names of months
 % biblatex has a "useprefix" option, which makes "von" count for alphabetization; the Glossa Stylesheet wants that, so it is important that this option be enabled (even if an author tries to set it to false)
 
-\ExecuteBibliographyOptions{labeldateparts,sorting=nyt,abbreviate,dateabbrev=false,useprefix=true}
+% For backward compatibility: choose labeldate or labeldateparts depending on the biblatex version
+\@ifpackagelater{biblatex}{2016/09/09}
+{%
+  \ExecuteBibliographyOptions{labeldateparts} % as of biblatex 3.5 (2016/09/10)
+}
+{%
+  \ExecuteBibliographyOptions{labeldate}
+  \def\printlabeldateextra{\printdateextralabel}
+}%
+
+\ExecuteBibliographyOptions{sorting=nyt,abbreviate,dateabbrev=false,useprefix=false}
 
 % biblatex by default calls biblatex.def, we add to this authoryear.bbx, which in turn loads standard.bbx. So, sp-biblatex.bbx is built on top of those styles; once authoryear.bbx is loaded, we tell it not to put in dashes for repeated authors (in accordance with the Unified Stylesheet)
 

--- a/gl-authoryear-comp.cbx
+++ b/gl-authoryear-comp.cbx
@@ -1,6 +1,16 @@
 \ProvidesFile{sp-authoryear-comp.cbx}
 
-\ExecuteBibliographyOptions{labeldateparts,uniquename,uniquelist,autocite=inline}
+% For backward compatibility: choose labeldate or labeldateparts depending on the biblatex version
+\@ifpackagelater{biblatex}{2016/09/09}
+{%
+  \ExecuteBibliographyOptions{labeldateparts} % as of biblatex 3.5 (2016/09/10)
+}
+{%
+  \ExecuteBibliographyOptions{labeldate}
+}%
+
+\ExecuteBibliographyOptions{uniquename=minfull,uniquelist=minyear,autocite=inline}
+
 % disabled sortcites option, since it was sorting by name, instead of year, and we often want to keep citations in the order chosen by the author
 \newbool{cbx:parens}
 


### PR DESCRIPTION
This commit makes the Biblatex files backwards compatible with versions
of Biblatex prior to 3.5. See also https://github.com/semprag/biblatex-sp-unified/pull/27/.