### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/biblatex-gl.bbx
+++ b/biblatex-gl.bbx
@@ -347,8 +347,8 @@
 \DeclareFieldFormat{pages}{#1}     % no pp. prefix, took \mkpageprefix out [kvf]
 \DeclareFieldFormat{doi}{%
   \ifhyperref
-    {\href{http://dx.doi.org/#1}{\nolinkurl{http://dx.doi.org/#1}}}
-    {\nolinkurl{http://dx.doi.org/#1}}}
+    {\href{https://doi.org/#1}{\nolinkurl{https://doi.org/#1}}}
+    {\nolinkurl{https://doi.org/#1}}}
 \DeclareFieldFormat{url}{\url{#1}}
 
 % This is for printing the volume field of a proceedings with an ISSN as an article

--- a/glossa.cls
+++ b/glossa.cls
@@ -180,7 +180,7 @@
                 pdfpagelabels,
                 bookmarks=false,
                 pdfstartview=FitH]{hyperref}
-\newcommand{\doi}[1]{\url{http://dx.doi.org/#1}}
+\newcommand{\doi}[1]{\url{https://doi.org/#1}}
 \urlstyle{rm}
 \RequirePackage[leqno,tbtags]{amsmath}
 % If the author is using postscript (discouraged), then load the breakurl package, else don't load it.
@@ -357,7 +357,7 @@
       }{}% closes \ifthenelse
       \begin{minipage}[c]{5.25in}
         \href{http://glossa.ubiquitypress.com/}{Glossa} Volume \@spvolume, Article \@sparticle: 1--\@splastpage, \@spyear\\
-        \href{http://dx.doi.org/10.5334/sp.\@spvolume.\@sparticle}{http://dx.doi.org/10.5334/.\@spvolume.\@sparticle}
+        \href{https://doi.org/10.5334/sp.\@spvolume.\@sparticle}{https://doi.org/10.5334/.\@spvolume.\@sparticle}
       \end{minipage}%
     }%
     \renewcommand{\@oddfoot}{%
@@ -400,7 +400,7 @@
       }{}% closes \ifthenelse
       \begin{minipage}[c]{5.25in}
         \href{http://http://glossa.ubiquitypress.com/}{Glossa} Volume \@spvolume, Article \@sparticle: 1--\@splastpage, \@spyear\\
-        \href{http://dx.doi.org/\@spdoi}{http://dx.doi.org/\@spdoi}
+        \href{https://doi.org/\@spdoi}{https://doi.org/\@spdoi}
       \end{minipage}%
       \gdef\@articlenumber{\@sparticle}
     }%

--- a/sample.bib
+++ b/sample.bib
@@ -93,7 +93,7 @@
 	Title = {A morphosyntactic decomposition of countability in {G}ermanic},
 	Volume = {14},
 	Year = {2011},
-	Bdsk-Url-1 = {http://dx.doi.org/10.1007/s10828-011-9045-0}}
+	Bdsk-Url-1 = {https://doi.org/10.1007/s10828-011-9045-0}}
 
 @book{blevins:2004,
 	Address = {Cambridge},


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update the example DOI link and any code that generates new DOI links.

Cheers!